### PR TITLE
V8を有効にする

### DIFF
--- a/dist/appsscript.json
+++ b/dist/appsscript.json
@@ -16,5 +16,6 @@
     "https://www.googleapis.com/auth/calendar",
     "https://www.googleapis.com/auth/script.scriptapp"
   ],
-  "exceptionLogging": "STACKDRIVER"
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8"
 }


### PR DESCRIPTION
refs: https://developers.google.com/apps-script/guides/v8-runtime#enabling_the_v8_runtime , https://developers.google.com/apps-script/guides/v8-runtime/migration

## 概要

V8を使えるようになったので有効にする
V8になるとES2015以降のjsの構文が使えるようになる。が、今の所babelでtranspileしているのでそこまで旨味はない
ただV8にはjitがあるので速度向上が見込める。gasは処理時間に制限があるのでその点は嬉しい